### PR TITLE
Make sure pointer is initialized with nullptr

### DIFF
--- a/DeviceProber.cpp
+++ b/DeviceProber.cpp
@@ -8,7 +8,7 @@
 
 #include "DeviceProber.h"
 
-DeviceProber::DeviceProber(IDeckLink* deckLink) : m_refCount(1), m_deckLink(deckLink)
+DeviceProber::DeviceProber(IDeckLink* deckLink) : m_refCount(1), m_deckLink(deckLink), m_captureDelegate(nullptr)
 {
 	m_deckLink->AddRef();
 	m_deckLinkAttributes = queryAttributesInterface();


### PR DESCRIPTION
If the value is not explicitly initialized with nullptr, the rest of the code will assume it's pointing to an actual object, which is not the case.